### PR TITLE
Remove seo tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -39,8 +39,6 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  {% seo %}
-
   {% include head_custom.html %}
 
 </head>


### PR DESCRIPTION
Having an error when running theme locally:
```
  Liquid Exception: Liquid syntax error (/srv/jekyll/_includes/head.html line 42): Unknown tag 'seo' included in /srv/jekyll/_layouts/default.html
```